### PR TITLE
Fix(2): TEXT() should not respect the scale in number/currency/percent field

### DIFF
--- a/src/builtin/string.ts
+++ b/src/builtin/string.ts
@@ -434,7 +434,8 @@ export default {
               zpadded.substring(newDotIndex).replace(".", ""),
             ]
               .join(".")
-              .replace(/(^0+|\.0*$)/g, "")
+              .replace(/^0+|0+$/g, "")
+              .replace(/\.$/g, "")
           );
         }
       }

--- a/test/fixtures/test-records.yml
+++ b/test/fixtures/test-records.yml
@@ -83,6 +83,16 @@
   Percent01__c: 89.4
   Number01__c: 250
 -
+  Percent02__c: 0.12
+-
+  Percent02__c: 1.2
+-
+  Percent02__c: 12
+-
+  Percent02__c: 120
+-
+  Percent02__c: 1200
+-
   Number01__c: 0
   Number02__c: 1250.8359
   Percent02__c: 89.6


### PR DESCRIPTION
Fixes #27 