### PR TITLE
Fix raising catch error success

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sformula",
   "description": "Library for parsing / evaluating Salesforce formula in client-side JavaScript",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "main": "lib/index.js",
   "module": "module/index.js",
   "types": "types/index.d.ts",

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,3 +1,5 @@
+import assert from "assert";
+
 export function zeropad(n: number): string {
   return (n < 10 ? "00" : n < 100 ? "0" : "") + String(n);
 }
@@ -7,4 +9,18 @@ export function escapeXml(str: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
+}
+
+export async function catchError(
+  execCb: () => Promise<void>,
+  errorCb: (e: Error) => void,
+  message?: string
+): Promise<void> {
+  try {
+    await execCb();
+  } catch (e) {
+    errorCb(e);
+    return;
+  }
+  assert.fail(message ?? "should raise error in execution");
 }


### PR DESCRIPTION
In try/catch error test, move assertion of not-reaching success execution out of the try clause.