### PR TITLE
Allow bracket identifier in specified name holder object

### DIFF
--- a/src/formula.ts
+++ b/src/formula.ts
@@ -1,10 +1,22 @@
 import { parse } from "./parser";
 import { SyntaxError } from "./error";
+import {
+  resetBracketIdentifierHolder,
+  setBracketIdentifierHolder,
+} from "./parserUtils";
 
-export const parseFormula = (text: string) => {
+export const parseFormula = (
+  text: string,
+  options: { bracketIdentifierHolder?: string } = {}
+) => {
   try {
+    if (options.bracketIdentifierHolder) {
+      setBracketIdentifierHolder(options.bracketIdentifierHolder);
+    }
     return parse(text);
   } catch (e) {
     throw new SyntaxError(e.message, e.expected, e.found, e.location);
+  } finally {
+    resetBracketIdentifierHolder();
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export type SyncParseOptions = {
   returnType?: FormulaReturnType;
   scale?: number;
   blankAsZero?: boolean;
+  bracketIdentifierHolder?: string;
 };
 
 export type Describer = {
@@ -70,12 +71,7 @@ export type Describer = {
   describe: (sobject: string) => Promise<DescribeSObjectResult>;
 };
 
-export type ParseOptions = {
-  inputTypes?: ExpressionTypeDictionary;
-  returnType?: FormulaReturnType;
-  scale?: number;
-  blankAsZero?: boolean;
-} & Describer;
+export type ParseOptions = SyncParseOptions & Describer;
 
 /**
  *
@@ -169,7 +165,7 @@ export function parseSync(
   formula: string,
   options: SyncParseOptions = {}
 ): Formula {
-  const ast = parseFormula(formula);
+  const ast = parseFormula(formula, options);
   return compileSync(ast, options);
 }
 

--- a/src/parserUtils.ts
+++ b/src/parserUtils.ts
@@ -13,6 +13,20 @@ import type {
   SourceLocation,
 } from "esformula";
 
+/* ------------------------------------------------------------------------- */
+
+let _bracketIdentifierHolder: string | undefined = undefined;
+
+export function setBracketIdentifierHolder(name: string) {
+  _bracketIdentifierHolder = name;
+}
+
+export function resetBracketIdentifierHolder() {
+  _bracketIdentifierHolder = undefined;
+}
+
+/* ------------------------------------------------------------------------- */
+
 export function isReserved(id: string) {
   return /^(TRUE|FALSE|NULL)$/i.test(id);
 }
@@ -128,6 +142,17 @@ export function createFieldExpression(
     };
   }
   return expression;
+}
+
+export function createBracketFieldPath(
+  name: string,
+  loc: SourceLocation
+): Identifier[] {
+  const id = createIdentifier(name, loc);
+  if (_bracketIdentifierHolder) {
+    return [createIdentifier(_bracketIdentifierHolder, loc), id];
+  }
+  return [id];
 }
 
 export function createIdentifier(

--- a/test/static.test.ts
+++ b/test/static.test.ts
@@ -443,9 +443,9 @@ test("class and type parameters", async () => {
   );
 });
 
-test("accept process builder bracket syntax", async () => {
+test("accept process builder bracket syntax", () => {
   const formula1 = "ISBLANK([Sales__c].AccountingDate__c)";
-  const fml1 = await parseSync(formula1, {
+  const fml1 = parseSync(formula1, {
     inputTypes: {
       Sales__c: {
         type: "object",
@@ -462,7 +462,7 @@ test("accept process builder bracket syntax", async () => {
   assert(ret1 === true);
 
   const formula2 = "ISBLANK([Sales Result].AccountingDate__c)";
-  const fml2 = await parseSync(formula2, {
+  const fml2 = parseSync(formula2, {
     inputTypes: {
       "Sales Result": {
         type: "object",
@@ -479,6 +479,37 @@ test("accept process builder bracket syntax", async () => {
   assert(ret2 === true);
 });
 
+test("evacuate bracket identifier in separate holder object", () => {
+  const formula3 = "[ObjOrField__c].Name + ', ' + ObjOrField__c";
+  const fml3 = parseSync(formula3, {
+    inputTypes: {
+      __: {
+        type: "object",
+        properties: {
+          ObjOrField__c: {
+            type: "object",
+            properties: {
+              Name: {
+                type: "string",
+              },
+            },
+          },
+        },
+      },
+      ObjOrField__c: {
+        type: "string",
+      },
+    },
+    returnType: "string",
+    bracketIdentifierHolder: "__",
+  });
+  const ret3 = fml3.evaluate({
+    __: { ObjOrField__c: { Name: "Hello" } },
+    ObjOrField__c: "World",
+  });
+  assert(ret3 === "Hello, World");
+});
+
 test("accept block comments", async () => {
   const formula1 = `
   /* First comment */
@@ -488,7 +519,7 @@ test("accept block comments", async () => {
    * Hello, programmers! */
   `;
 
-  const fml1 = await parseSync(formula1, {
+  const fml1 = parseSync(formula1, {
     inputTypes: {
       Account: {
         type: "object",


### PR DESCRIPTION
Currently the bracket-enclosed identifier is resolved as same as non bracket-enclosed identifier, which might introduce confusion in scenario where object name and field name is the same and has both access path, like:

```
[Contact__c].Email == Contact__c
```
Above example, the `[Contact__c]` wants to refer specified custom object access, and latter `Contact__c` refer to a custom field in the context object.

In order to avoid the confliction, it introduces an evacuation option by holding the bracket-enclosed identifier in specified holder object passed in `bracketIdentifierHolder` parser option.

```javascript
import { parseSync } from 'sformula';
// ...
const fml = parseSync("[Contact__c].Email == Contact__c", {
  inputTypes: {
    __: {
      type: "object",
      properties: {
        Contact__c: {
          type: "object",
          properties: {
            Email: { type: "string" },
          },
        },
      },
    },
    Contact__c: {
      type: "string",
    },
  },
  returnType: "boolean",
  bracketIdentifierHolder: "__",
});
fml.evaluate({
  __: { Contact__c: { Email: "abc@example.org" } },
  Contact__c: "def@example.net",
});
```