### PR TITLE
Fix to pass option in async parse call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ export async function parse(
   formula: string,
   options: ParseOptions
 ): Promise<Formula> {
-  const ast = parseFormula(formula);
+  const ast = parseFormula(formula, options);
   return compile(ast, options);
 }
 


### PR DESCRIPTION
Fixing `bracketIdentifierHolder` is not passed in async parse call