### PR TITLE
fix to cast to string for id fields in object member

### DIFF
--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -134,8 +134,13 @@ for (const [i, formulaDef] of formulaDefs.entries()) {
     });
     for (const [i, rec] of testRecords.entries()) {
       const fetchedRecord = expectedRecords[i];
-      const { Id, Parent__c, [name]: expected } = fetchedRecord;
-      const record = { ...rec, Id, Parent__c };
+      const { Id, Parent__c, Parent__r, [name]: expected } = fetchedRecord;
+      const record = {
+        ...rec,
+        Id,
+        Parent__c,
+        Parent__r: Parent__r ? { ...Parent__r } : null,
+      };
       // Test result may differ from expected if relative datetime values are included in the formula (e.g. "NOW()").
       // So applying fluctuation value to the expected value and assert the result is in the range.
       if (fluctuation > 0) {

--- a/test/fixtures/formula-defs.yml
+++ b/test/fixtures/formula-defs.yml
@@ -679,6 +679,9 @@
   formula: Id & '; ' & Parent__c
 -
   type: Text
+  formula: Id + '; ' + Parent__r.Id
+-
+  type: Text
   formula: |
     /* This is comment */
     Text01__c + /* Second comment */ ' ' + Text02__c


### PR DESCRIPTION
It raise comile error when parsing `"/" + Parent__r.Id` formula, while `"/" + Parent__c` does not yield any errors