### PR TITLE
Eliminate rounding error by introducing bignumber.js in number calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.20.6",
+    "bignumber.js": "^9.1.2",
     "dayjs": "^1.11.3",
     "esformula": "^3.0.0"
   },

--- a/src/builtin/common.ts
+++ b/src/builtin/common.ts
@@ -92,35 +92,6 @@ export function convertIdFrom18To15(s: string) {
 /**
  *
  */
-export function shiftDecimalPoint(n: number, d: number): number {
-  if (n === 0) {
-    return n;
-  }
-  const sign = n > 0 ? 1 : -1;
-  const s = String(n * sign);
-  // give up accurate shift if it is floating number
-  if (s.indexOf("e") >= 0) {
-    return n * 10 ** -d;
-  }
-  const zeros = Array.from({ length: Math.abs(d) })
-    .map(() => "0")
-    .join("");
-  const zpadded = zeros + s + (s.indexOf(".") < 0 ? "." : "") + zeros;
-  const dindex = zpadded.indexOf(".");
-  const ndindex = dindex - (d > 0 ? d : d - 1);
-  const ss = [
-    zpadded.substring(0, ndindex).replace(/\./g, ""),
-    zpadded.substring(ndindex).replace(/\./g, ""),
-  ]
-    .join(".")
-    .replace(/^0+/, "");
-  const nn = Number(ss);
-  return sign * nn;
-}
-
-/**
- *
- */
 export function escapeHtml(str: string): string {
   return str
     .replace(/&/g, "&amp;")

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -1,4 +1,8 @@
-import type { Context, ExpressionTypeDictionary } from "../types";
+import type {
+  Context,
+  ExpressionTypeDictionary,
+  FunctionDefDictionary,
+} from "../types";
 import stringBuiltins from "./string";
 import datetimeBuiltins from "./datetime";
 import logicBuiltins from "./logic";
@@ -11,7 +15,7 @@ const builtins = {
   ...logicBuiltins,
   ...numberBuiltins,
   ...operatorBuiltins,
-};
+} satisfies FunctionDefDictionary;
 
 export type BuiltinFunctionName = keyof typeof builtins;
 

--- a/src/builtin/logic.ts
+++ b/src/builtin/logic.ts
@@ -1,11 +1,12 @@
-import type { Maybe } from "../types";
+import type { FunctionDefDictionary } from "../types";
+import type { SfBoolean, SfAnyData, SfString } from "./types";
 
 /**
  *
  */
-export default {
+export const logicBuiltins = {
   AND: {
-    value: (...conds: Array<boolean | null | undefined>) => {
+    value: (...conds: SfBoolean[]) => {
       let ret: boolean | null = true;
       for (const c of conds) {
         if (c === false) {
@@ -27,7 +28,7 @@ export default {
     },
   },
   OR: {
-    value: (...conds: Array<boolean | null | undefined>) => {
+    value: (...conds: SfBoolean[]) => {
       let ret: boolean | null = false;
       for (const c of conds) {
         if (c === true) {
@@ -49,7 +50,7 @@ export default {
     },
   },
   NOT: {
-    value: (v: boolean | null | undefined) => {
+    value: (v: SfBoolean) => {
       if (v == null) {
         return null;
       }
@@ -67,7 +68,7 @@ export default {
     },
   },
   CASE: {
-    value: (...args: Array<any>) => {
+    value: (...args: SfAnyData[]) => {
       const value = args[0] == null ? "" : args[0];
       for (let i = 1; i < args.length - 1; i += 2) {
         const match = args[i] == null ? "" : args[i];
@@ -111,7 +112,7 @@ export default {
     },
   },
   IF: {
-    value: (test: boolean, cons: any, alt: any) => {
+    value: (test: SfBoolean, cons: SfAnyData, alt: SfAnyData) => {
       return test ? cons : alt;
     },
     type: {
@@ -134,7 +135,7 @@ export default {
     },
   },
   ISNULL: {
-    value: (value: any) => {
+    value: (value: SfAnyData) => {
       return value == null;
     },
     type: {
@@ -149,7 +150,7 @@ export default {
     },
   },
   ISBLANK: {
-    value: (value: any) => {
+    value: (value: SfAnyData) => {
       return value == null || value === "";
     },
     type: {
@@ -164,10 +165,11 @@ export default {
     },
   },
   ISNUMBER: {
-    value: (value: Maybe<string>) => {
+    value: (value: SfString) => {
       if (!value) {
         return null;
       }
+      // Strings representing binary, octal, or hexadecimal numbers are not treated as numbers.
       if (/^-?0[box]/i.test(value)) {
         return false;
       }
@@ -186,7 +188,7 @@ export default {
     },
   },
   NULLVALUE: {
-    value: (value: any, alt: any) => {
+    value: (value: SfAnyData, alt: SfAnyData) => {
       return value == null ? alt : value;
     },
     type: {
@@ -205,7 +207,7 @@ export default {
     },
   },
   BLANKVALUE: {
-    value: (value: any, alt: any) => {
+    value: (value: SfAnyData, alt: SfAnyData) => {
       return value == null || value === "" ? alt : value;
     },
     type: {
@@ -223,4 +225,6 @@ export default {
       returns: { type: "template", ref: "T" },
     },
   },
-};
+} satisfies FunctionDefDictionary;
+
+export default logicBuiltins;

--- a/src/builtin/number.ts
+++ b/src/builtin/number.ts
@@ -65,9 +65,7 @@ const numberBuiltins = {
       if (v == null || d == null) {
         return null;
       }
-      const places = BigNumber(d)
-        .integerValue(BigNumber.ROUND_FLOOR)
-        .toNumber();
+      const places = BigNumber(d).integerValue(BigNumber.ROUND_DOWN).toNumber();
       if (places >= 0) {
         return BigNumber(v).decimalPlaces(places, BigNumber.ROUND_HALF_UP);
       } else {

--- a/src/builtin/operator.ts
+++ b/src/builtin/operator.ts
@@ -440,7 +440,7 @@ const operatorBuiltins = {
       if (!dt.isValid()) {
         return null;
       }
-      const nn = BigNumber(n).toNumber();
+      const nn = BigNumber(n).integerValue(BigNumber.ROUND_DOWN).toNumber();
       const ms = dayjs.duration(nn, "day").asMilliseconds();
       return dt.add(ms, "millisecond").format(ISO8601_DATE_FORMAT);
     },
@@ -468,9 +468,8 @@ const operatorBuiltins = {
       if (!dt.isValid()) {
         return null;
       }
-      const ms = dayjs
-        .duration(BigNumber(n).toNumber(), "day")
-        .asMilliseconds();
+      const nn = BigNumber(n).integerValue(BigNumber.ROUND_DOWN).toNumber();
+      const ms = dayjs.duration(nn, "day").asMilliseconds();
       return dt.add(-ms, "millisecond").format(ISO8601_DATE_FORMAT);
     },
     type: {

--- a/src/builtin/types.ts
+++ b/src/builtin/types.ts
@@ -1,0 +1,16 @@
+import type { BigNumber } from "bignumber.js";
+import type { Maybe } from "../types";
+
+export type SfString = Maybe<string>;
+export type SfNumber = Maybe<number | BigNumber>;
+export type SfBoolean = Maybe<boolean>;
+export type SfDate = Maybe<string>;
+export type SfDatetime = Maybe<string>;
+export type SfTime = Maybe<string>;
+export type SfAnyData =
+  | SfString
+  | SfNumber
+  | SfBoolean
+  | SfDate
+  | SfDatetime
+  | SfTime;

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -153,7 +153,7 @@ function traverseUnaryExpression(
   }
   switch (argumentType.type) {
     case "number":
-      if (operator !== "-" && operator === "+") {
+      if (operator !== "-" && operator !== "+") {
         throw new InvalidOperatorError(
           expression.argument,
           argumentTypeId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,9 @@ export type PrimitiveExpressionType =
       type: "time";
     }
   | {
+      type: "html";
+    }
+  | {
       type: "any";
     };
 
@@ -57,18 +60,29 @@ export type FunctionArgType = {
   optional: boolean;
 };
 
+export type FunctionType = {
+  type: "function";
+  arguments: FunctionArgType[] | ((p: number) => FunctionArgType[]);
+  returns: ExpressionType;
+};
+
+export type FunctionDef = {
+  value: (...args: any[]) => any;
+  type: FunctionType;
+};
+
+export type FunctionDefDictionary = {
+  [key: string]: FunctionDef;
+};
+
 export type ExpressionType =
   | PrimitiveExpressionType
   | AdditionalPrimitiveExpressionType
+  | FunctionType
   | {
       type: "object";
       sobject?: string;
       properties: ExpressionTypeDictionary;
-    }
-  | {
-      type: "function";
-      arguments: FunctionArgType[] | ((p: number) => FunctionArgType[]);
-      returns: ExpressionType;
     }
   | {
       type: "class";

--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -37,6 +37,10 @@ beforeAll(async () => {
 /**
  *
  */
+const targetFormulaNo = process.env.TEST_FORMULA_NO
+  ? parseInt(process.env.TEST_FORMULA_NO, 10)
+  : null;
+
 for (const [i, formulaDef] of formulaDefs.entries()) {
   const {
     type,
@@ -46,10 +50,13 @@ for (const [i, formulaDef] of formulaDefs.entries()) {
     blankAsZero,
     fluctuation = 0,
   } = formulaDef;
-  /**
-   *
-   */
-  test(`formula#${zeropad(i + 1)}: ${formula}${
+
+  const formulaNo = i + 1;
+  if (targetFormulaNo && formulaNo !== targetFormulaNo) {
+    continue;
+  }
+
+  test(`formula#${zeropad(formulaNo)}: ${formula}${
     blankAsZero ? " (blank as zero) " : ""
   }`, async () => {
     if (expectedRecords?.length !== testRecords?.length) {

--- a/test/fixtures/formula-defs.yml
+++ b/test/fixtures/formula-defs.yml
@@ -3,6 +3,14 @@
   precision: 18
   scale: 0
 - type: Number
+  formula: 0.1 + 0.2
+  precision: 18
+  scale: 2
+- type: Number
+  formula: 0.3 - 0.1
+  precision: 18
+  scale: 2
+- type: Number
   formula: 6 / 3 * 2
   precision: 18
   scale: 0
@@ -139,6 +147,10 @@
   formula: Time01__c < Time02__c + 5 * 60 * 60 * 1000
 - type: Checkbox
   formula: Time01__c > Time02__c - 10 * 60 * 60 * 1000
+- type: Number
+  formula: -Number01__c
+  precision: 18
+  scale: 2
 - type: Number
   formula: +Number02__c
   precision: 18

--- a/test/fixtures/formula-defs.yml
+++ b/test/fixtures/formula-defs.yml
@@ -114,6 +114,8 @@
 - type: Date
   formula: Date01__c + Number01__c
 - type: Date
+  formula: Date01__c - Number01__c
+- type: Date
   formula: Date01__c + 0.5
 - type: Date
   formula: Datetime01__c - 0.5

--- a/test/fixtures/formula-defs.yml
+++ b/test/fixtures/formula-defs.yml
@@ -138,6 +138,10 @@
 - type: Checkbox
   formula: Time01__c > Time02__c - 10 * 60 * 60 * 1000
 - type: Number
+  formula: +Number02__c
+  precision: 18
+  scale: 2
+- type: Number
   formula: Percent01__c * Number01__c
   precision: 18
   scale: 2

--- a/test/fixtures/test-records.yml
+++ b/test/fixtures/test-records.yml
@@ -218,3 +218,19 @@
   Number01__c: 1
 - Date01__c: "2019-05-30"
   Number01__c: 1
+- Date01__c: "2019-05-30"
+  Number01__c: 1
+- Date01__c: "2020-01-14"
+  Number01__c: 1.21
+- Date01__c: "2019-12-30"
+  Number01__c: 1.65
+- Date01__c: "2019-10-31"
+  Number01__c: -2.8
+  Number02__c: -987.654321
+  Percent01__c: 0.85
+  Percent02__c: 45.45
+- Date01__c: "2019-11-01"
+  Number01__c: -1.45
+  Number02__c: 12.3456789
+  Percent01__c: 24
+  Percent02__c: -0.345

--- a/test/number.test.ts
+++ b/test/number.test.ts
@@ -1,0 +1,75 @@
+import assert from "assert";
+import { parseSync } from "../src";
+
+/**
+ *
+ */
+describe("number calculations", () => {
+  test("should handle floating point calculations without rounding errors", () => {
+    const cases = [
+      { formula: "0.1 + 0.2", expected: 0.3 },
+      { formula: "0.3 - 0.1", expected: 0.2 },
+      { formula: "0.7 * 0.1", expected: 0.07 },
+      { formula: "0.3 / 0.1", expected: 3 },
+      { formula: "1.0 - 0.9", expected: 0.1 },
+      { formula: "0.1 * 0.1", expected: 0.01 },
+    ];
+
+    for (const { formula, expected } of cases) {
+      const fml = parseSync(formula, { returnType: "number" as const });
+      const result = fml.evaluate({});
+      assert.strictEqual(result, expected, `Failed for ${formula}`);
+    }
+  });
+
+  test("should handle percentage calculations correctly", () => {
+    const cases: Array<{
+      formula: string;
+      inputs: Record<string, number>;
+      expected: number;
+      returnType: "number" | "percent";
+      scale?: number;
+    }> = [
+      {
+        formula: "Number01__c / Number02__c",
+        inputs: { Number01__c: 1, Number02__c: 3 },
+        expected: 0.3333333333,
+        returnType: "number",
+        scale: 10,
+      },
+      {
+        formula: "Percent01__c",
+        inputs: { Percent01__c: 25 },
+        expected: 25,
+        returnType: "percent",
+      },
+      {
+        formula: "Percent01__c + Percent02__c",
+        inputs: { Percent01__c: 25, Percent02__c: 75 },
+        expected: 100,
+        returnType: "percent",
+      },
+      {
+        formula: "Percent01__c * Number01__c",
+        inputs: { Percent01__c: 25, Number01__c: 200 },
+        expected: 50,
+        returnType: "number",
+      },
+    ];
+
+    for (const { formula, inputs, expected, scale, returnType } of cases) {
+      const fml = parseSync(formula, {
+        inputTypes: {
+          Number01__c: { type: "number" },
+          Number02__c: { type: "number" },
+          Percent01__c: { type: "percent" },
+          Percent02__c: { type: "percent" },
+        },
+        scale,
+        returnType,
+      });
+      const result = fml.evaluate(inputs);
+      assert.strictEqual(result, expected, `Failed for ${formula}`);
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2341,6 +2341,11 @@ base64url@^3.0.1:
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
   integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
 
+bignumber.js@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"


### PR DESCRIPTION
As the JavaScript number calculation is floating number, rounding errors will happen when doing calculation.
Using `bignumber.js`, the calculation is done in arbitrary-precision.