### PR TITLE
fix CASE() value comparison is not made correctly for bignumber

### DIFF
--- a/src/builtin/logic.ts
+++ b/src/builtin/logic.ts
@@ -1,5 +1,5 @@
 import type { FunctionDefDictionary } from "../types";
-import type { SfBoolean, SfAnyData, SfString } from "./types";
+import { type SfBoolean, type SfAnyData, type SfString, isEquivalent } from "./types";
 
 /**
  *
@@ -69,11 +69,11 @@ export const logicBuiltins = {
   },
   CASE: {
     value: (...args: SfAnyData[]) => {
-      const value = args[0] == null ? "" : args[0];
+      const value = args[0];
       for (let i = 1; i < args.length - 1; i += 2) {
-        const match = args[i] == null ? "" : args[i];
+        const match = args[i];
         const ret = args[i + 1];
-        if (match === value) {
+        if (isEquivalent(match, value)) {
           return ret;
         }
       }

--- a/src/builtin/types.ts
+++ b/src/builtin/types.ts
@@ -1,4 +1,4 @@
-import type { BigNumber } from "bignumber.js";
+import { BigNumber } from "bignumber.js";
 import type { Maybe } from "../types";
 
 export type SfString = Maybe<string>;
@@ -14,3 +14,20 @@ export type SfAnyData =
   | SfDate
   | SfDatetime
   | SfTime;
+
+function isNumber(v: SfAnyData): v is NonNullable<SfNumber> {
+  return BigNumber.isBigNumber(v) || typeof v === 'number';
+}
+
+export function isEquivalent(v1: SfAnyData, v2: SfAnyData): boolean {
+  if (v1 === v2) {
+    return true;
+  }
+  if ((v1 == null || v1 === '') && (v2 == null || v2 === '')) {
+    return true;
+  }
+  if (isNumber(v1) && isNumber(v2)) {
+    return BigNumber(v1).isEqualTo(v2);
+  }
+  return false;
+}

--- a/test/fixtures/formula-defs.yml
+++ b/test/fixtures/formula-defs.yml
@@ -538,3 +538,5 @@
   formula: IMAGE(Url01__c, Text01__c, Number01__c, Number02__c)
 - type: Text
   formula: HYPERLINK(Url02__c, IMAGE(Url01__c, Text01__c), Text02__c)
+- type: Text
+  formula: CASE(MOD(Number01__c, 2), 0, Text01__c, 1, Text02__c, NULL)


### PR DESCRIPTION
Fixes the issue of
- When the `CASE()` has a big number value to match, it always goes to fallback even if there are matching values.